### PR TITLE
fix memrchr detection

### DIFF
--- a/util/string_util.h
+++ b/util/string_util.h
@@ -41,7 +41,13 @@ inline int strncasecmp(const char* s1, const char* s2, size_t n) {
 #endif
 }
 
-#if !defined(__linux__)
+#ifndef HAVE_MEMRCHR
+#if defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 2)))
+#define HAVE_MEMRCHR
+#endif
+#endif
+
+#ifndef HAVE_MEMRCHR
 inline void* memrchr(const void* s, int c, size_t n) {
   const unsigned char* p = (const unsigned char*) s;
   for (p += n; n > 0; n--) {


### PR DESCRIPTION
This function is defined not on Linux but on GNU, that is, systems with glibc 2.2 or higher; also, use an intermediate `HAVE_MEMRCHR` symbol that people with alternative C libraries can define to indicate its presence.

This fix is necessary to allow building on GNU/Hurd and GNU/kFreeBSD, both of which have architectures present in Debian.